### PR TITLE
Fix two issues in the repo

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -34,25 +34,25 @@ int logFileCreated = 0;
 void log_file (char *message)
 {
     FILE *file;
- 
+
     if (!logFileCreated) {
         file = fopen(LOGFILE, "w");
-	logFileCreated = 1;
+        logFileCreated = 1;
     }
-    else		
-	file = fopen(LOGFILE, "a");
-		
+    else
+        file = fopen(LOGFILE, "a");
+
     if (file == NULL) {
-	if (logFileCreated)
-	    logFileCreated = 0;
-	    return;
+        if (logFileCreated)
+            logFileCreated = 0;
+            return;
     }
     else
     {
-	fputs(message, file);
-	(file);
+        fputs(message, file);
+        (file);
     }
- 
+
     if (file)
-	fclose(file);
+        fclose(file);
 }

--- a/src/log.h
+++ b/src/log.h
@@ -2,7 +2,7 @@
 #define _log_h
 #include <stdio.h>
 
-#define LOGFILE	"x4.log"
+#define LOGFILE    "x4.log"
 extern int logFileCreated;
 
 void log_file (char *message);

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <time.h>
+#include <unistd.h>
 #include "init.h"
 #include "log.h"
 #include "timers.h"


### PR DESCRIPTION
First commit fixes this warning: main.c:27:9: warning: implicit declaration of function 'sleep' is invalid in C99 [-Wimplicit-function-declaration] sleep(delay);
Second resolves all the shouting vim did when I opened the file to view (mix of tabs and spaces, converted to spaces only)